### PR TITLE
Missing library for gRPC compiled classes

### DIFF
--- a/chat-proto/pom.xml
+++ b/chat-proto/pom.xml
@@ -26,9 +26,15 @@
 			<artifactId>grpc-stub</artifactId>
 			<version>${io.grpc.version}</version>
 		</dependency>
+
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,11 @@
 				<artifactId>grpc-stub</artifactId>
 				<version>${io.grpc.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>javax.annotation</groupId>
+				<artifactId>javax.annotation-api</artifactId>
+				<version>1.3.2</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 	<modules>


### PR DESCRIPTION
I am using JDK 12 and I am missing javax annotation library after compilation, here:

```java
@javax.annotation.Generated(
    value = "by gRPC proto compiler (version 1.24.0)",
    comments = "Source: chat.proto")
public final class ChatServiceGrpc {
```