### PR TITLE
Add windows npm compilation run script

### DIFF
--- a/chat-webapp/package.json
+++ b/chat-webapp/package.json
@@ -6,6 +6,7 @@
     "start": "ng serve --host 0.0.0.0",
     "build": "ng build",
     "compile": "./node_modules/protoc/protoc/bin/protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --js_out=import_style=commonjs,binary:src/app/proto --ts_out=service=true:src/app/proto -I ../chat-proto/src/main/proto/ ../chat-proto/src/main/proto/*.proto",
+    "compile-win": ".\\node_modules\\protoc\\protoc\\bin\\protoc --plugin=protoc-gen-ts=.\\node_modules\\.bin\\protoc-gen-ts.cmd --js_out=import_style=commonjs,binary:src\\app\\proto --ts_out=service=true:src\\app\\proto -I ..\\chat-proto\\src\\main\\proto\\ ..\\chat-proto\\src\\main\\proto\\*.proto",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"


### PR DESCRIPTION
In windows protoc-gen-ts.cmd must be used and it doesn't work with unix directory separator. I created additional script. 